### PR TITLE
builder internal []byte is a clone of the one used in NewBuilder

### DIFF
--- a/insertablebuffer.go
+++ b/insertablebuffer.go
@@ -397,7 +397,11 @@ func (b *Builder) ReadString(delim byte) (line string, err error) {
 //
 // In most cases, new(Buffer) (or just declaring a Buffer variable) is
 // sufficient to initialize a Buffer.
-func NewBuilder(buf []byte) *Builder { return &Builder{buf: buf} }
+func NewBuilder(buf []byte) *Builder {
+	newbuf := make([]byte, len(buf))
+	copy(newbuf, buf)
+	return &Builder{buf: newbuf}
+}
 
 // NewBuilderString creates and initializes a new Buffer using string s as its
 // initial contents. It is intended to prepare a buffer to read an existing


### PR DESCRIPTION
Builder will now make a copy of the []byte.
This is to avoid the change of the []byte used as argument for NewBuilder without knowing it